### PR TITLE
overwrite region byte only

### DIFF
--- a/GCConverter/Form1.cs
+++ b/GCConverter/Form1.cs
@@ -130,11 +130,11 @@ namespace GCConverter
                 {
                     bw.BaseStream.Seek(0x3, SeekOrigin.Begin);
                     if (region == "PAL")
-                        bw.Write(0xFF313050);
+                        bw.Write((byte)0x50);
                     else if (region == "NTSC-U")
-                        bw.Write(0xFF313045);
+                        bw.Write((byte)0x45);
                     else if (region == "NTSC-J")
-                        bw.Write(0xFF31304A);
+                        bw.Write((byte)0x4A);
 
                     bw.Close();
                 }


### PR DESCRIPTION
The original code overwrites the publisher's byte with 01, which is Nintendo's code. As a result, only first-party Nintendo game saves can be successfully converted.
This change leaves the publisher's byte intact, so third-party game saves can be converted as well (tested with a couple of EA games)